### PR TITLE
update function

### DIFF
--- a/src/JsonTable.php
+++ b/src/JsonTable.php
@@ -341,33 +341,25 @@ class JsonTable
      *
      * @return int
      */
-    public function delete($key, $val = 0)
-    {
-        $result = 0;
-        if (is_array($key)) {
-            $result = $this->delete($key[1], $key[2]);
+    public function delete($key, $val = 0) {
+        if ( is_array( $key ) ) {
+            if ( count( $key ) == 3 )
+                return $this->delete($key[1], $key[2]);
+            return 0;
         } else {
             $data = $this->fileData;
+            $i = 0;
             foreach ($data as $_key => $_val) {
-
-                if ($val === false && $_key == $key) {
-                    unset($data[$_key]);
-                    $result++;
-                    break;
-                } elseif (isset($data[$_key][$key])) {
+                if ( isset( $data[$_key][$key] ) ) {
                     if ($data[$_key][$key] == $val) {
-                        unset($data[$_key]);
-                        $result++;
+                        unset( $data[$_key] );
+                        $i++;
                     }
                 }
             }
-            if ($result) {
-                sort($data);
-                $this->fileData = $data;
-            }
         }
+        $this->fileData = $data;
         $this->save();
-
-        return $result;
+        return $i;
     }
 }

--- a/src/JsonTable.php
+++ b/src/JsonTable.php
@@ -128,8 +128,10 @@ class JsonTable
             $flags = 0;
         }
 
-        if ($this->fileData == null || $this->fileData == '' || empty($this->fileData)) {
-            throw new JsonDBException('Refusing to write null data to: ' . $this->jsonFile);
+        if ( !is_array( $this->fileData ) ) {
+            if ($this->fileData == null || $this->fileData == '' || empty($this->fileData)) {
+                throw new JsonDBException('Refusing to write null data to: ' . $this->jsonFile);
+            }
         }
 
         ftruncate($this->fileHandle, 0);

--- a/src/JsonTable.php
+++ b/src/JsonTable.php
@@ -281,32 +281,25 @@ class JsonTable
      */
     public function update($key, $val = 0, $newData = array())
     {
-        $result = false;
-        if (is_array($key)) {
-            $result = $this->update($key[1], $key[2], $key[3]);
+        if ( is_array( $key ) ) {
+            if ( count( $key ) == 4 )
+                return $this->update( $key[1], $key[2], $key[3] );
         } else {
-            $data = $this->fileData;
-            foreach ($data as $_key => $_val) {
-
-                if ($val === false) {
-                    $data[$key] = $newData;
-                    $result     = true;
-                    break;
-                } elseif (isset($data[$_key][$key])) {
-                    if ($data[$_key][$key] == $val) {
-                        $data[$_key] = $newData;
-                        $result      = true;
-                        break;
-                    }
+            if( count( $this->select( $key, $val ) ) != 0 ) {
+                $data = $this->fileData;
+                $resultData = [];
+                foreach ($data as $_key => $_val) {
+                    if( $data[$_key][$key] == $val )
+                        array_push( $resultData, $newData );
+                    else
+                        array_push( $resultData, $_val);
                 }
-            }
-            if ($result) {
-                $this->fileData = $data;
-            }
+                $this->fileData = $resultData;
+                $this->save();
+                return true;
+            } else
+                return false;
         }
-        $this->save();
-
-        return $result;
     }
 
     /**


### PR DESCRIPTION
Maybe I wrong when I use the update function, when it's called the json file is written like a b64 format or binary file.

As I understand the update function JsonDB -> update ( "table", "key", "value", ARRAY ) is:
- table: represents obiously the json file as is used in others functions.
- key and value: like a where clausule in SQL language. (WHERE id = 5)
- ARRAY: is the new value of all row

I have this collection:

```
[
        {
            "nickname": "rabrux",
            "meta": {
                "fullname": "rabrux",
                "age": 25
            },
            "broadcast": 1,
            "createdAt": 1449708546
        },
        {
            "nickname": "w800",
            "meta": {
                "fullname": "W-800",
                "age": 25
            },
            "broadcast": 1,
            "op": true,
            "createdAt": 1449708546
        }
    ]
```

I need to update the "op" field in the item with the nickname "w800" to false or in this case unset the "op" field like:

```
{
    "nickname": "w800",
    "meta": {
      "fullname": "W-800",
      "age": 25
    },
    "broadcast": 1,
    "createdAt": 1449708546
  }
```

In this example, the result in the json file will be corrupt at the end of excecution of the update function.

If I wrong... Maybe you can explain me what are the correct way to use the update function.

At time I change all the update function to works like in the example.

Greetings...
